### PR TITLE
Switch to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:  
   directories:  
    - $HOME/.m2  


### PR DESCRIPTION
Travis does not support Oracle JDK 8 anymore. For that reason we switch to Open JDK.