### PR TITLE
Dependency Upgrades

### DIFF
--- a/bundles/edu.kit.ipd.sdq.metamodels.asem/.classpath
+++ b/bundles/edu.kit.ipd.sdq.metamodels.asem/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="src-gen-mod"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/edu.kit.ipd.sdq.metamodels.asem/META-INF/MANIFEST.MF
+++ b/bundles/edu.kit.ipd.sdq.metamodels.asem/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: edu.kit.ipd.sdq.metamodels.asem,
  edu.kit.ipd.sdq.metamodels.asem.base,
  edu.kit.ipd.sdq.metamodels.asem.base.impl,

--- a/bundles/edu.kit.ipd.sdq.metamodels.asem/build.properties
+++ b/bundles/edu.kit.ipd.sdq.metamodels.asem/build.properties
@@ -8,4 +8,4 @@ bin.includes = .,\
 jars.compile.order = .
 source.. = src-gen/,\
            src-gen-mod/
-output.. = bin/
+output.. = target/classes/

--- a/pom.xml
+++ b/pom.xml
@@ -29,19 +29,7 @@
 	</repositories>
 
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-				<configuration>
-					<compilerId>eclipse</compilerId>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-					<optimize>true</optimize>
-				</configuration>
-			</plugin>
-			
+		<plugins>	
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
@@ -74,6 +62,7 @@
 					</environments>
 				</configuration>
 			</plugin>
+
 			<!-- Creates source versions of bundles -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -88,6 +77,7 @@
 					</execution>
 				</executions>
 			</plugin>
+
 			<!-- Creates source versions of features -->
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
@@ -103,6 +93,7 @@
 					</execution>
 				</executions>
 			</plugin>
+
 			<!-- Correctly handles source features on p2 update site -->
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,17 +17,14 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<tycho.version>1.5.1</tycho.version>
+		<tycho.version>2.1.0</tycho.version>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>Eclipse</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2019-09</url>
+			<url>http://download.eclipse.org/releases/2020-12</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
- Upgrade to Java 11
- Upgrade to Eclipse 2020-12
- Update some Maven compile dependencies
- Remove unnecessary `maven-compiler-plugin`